### PR TITLE
Add Template hash and equality implementations

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -306,7 +306,7 @@ pub enum DataRecordKey {
     Err(String),
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum DataRecordType {
     UnsignedInt,
     SignedInt,

--- a/src/template_store.rs
+++ b/src/template_store.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ExpandedFieldSpecifier {
     pub name: DataRecordKey,
     pub ty: DataRecordType,
@@ -48,7 +48,7 @@ impl ExpandedFieldSpecifier {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Template {
     Template(Vec<ExpandedFieldSpecifier>),
     OptionsTemplate(Vec<ExpandedFieldSpecifier>),


### PR DESCRIPTION
This change adds `Hash, PartialEq, Eq` to `Template` and types used in its fields so that it's possible to add `Template` instances to hash maps/sets and check for equality.